### PR TITLE
#133 Allow private fields as properties

### DIFF
--- a/src/test/java/ch/jalu/configme/configurationdata/ConfigurationDataBuilderTest.java
+++ b/src/test/java/ch/jalu/configme/configurationdata/ConfigurationDataBuilderTest.java
@@ -7,6 +7,8 @@ import ch.jalu.configme.exception.ConfigMeException;
 import ch.jalu.configme.properties.Property;
 import ch.jalu.configme.samples.ClassWithPrivatePropertyField;
 import ch.jalu.configme.samples.TestConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -21,6 +23,10 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -79,16 +85,52 @@ class ConfigurationDataBuilderTest {
     }
 
     @Test
-    void shouldWrapIllegalAccessExceptionIntoConfigMeException() throws NoSuchFieldException {
+    void shouldAccessPrivateField() throws NoSuchFieldException {
         // given
         ConfigurationDataBuilder configurationDataBuilder = new ConfigurationDataBuilder();
         Field privateProperty = ClassWithPrivatePropertyField.class.getDeclaredField("PRIVATE_INT_PROPERTY");
 
-        // when / then
-        verifyException(
-            () -> configurationDataBuilder.getPropertyField(privateProperty),
-            ConfigMeException.class,
-            "Is it maybe not public?");
+        // when
+        Property<?> result = configurationDataBuilder.getPropertyField(privateProperty);
+
+        // then
+        assertThat(result, sameInstance(ClassWithPrivatePropertyField.getPrivatePropertyValue()));
+    }
+
+    @Test
+    void shouldThrowWrappedExceptionIfFieldCannotBeAccessed() throws NoSuchFieldException {
+        // given
+        ConfigurationDataBuilder configurationDataBuilder = new ConfigurationDataBuilder() {
+            @Override
+            protected void setFieldAccessibleIfNeeded(@NotNull Field field) {
+                // do nothing
+            }
+        };
+
+        Field privateProperty = ClassWithPrivatePropertyField.class.getDeclaredField("PRIVATE_INT_PROPERTY");
+
+        // when
+        ConfigMeException ex = assertThrows(ConfigMeException.class,
+            () -> configurationDataBuilder.getPropertyField(privateProperty));
+
+        // then
+        assertThat(ex.getMessage(), equalTo("Could not fetch field 'PRIVATE_INT_PROPERTY' from class 'ClassWithPrivatePropertyField'. Is it maybe not public?"));
+        assertThat(ex.getCause(), instanceOf(IllegalAccessException.class));
+    }
+
+    @Test
+    @Disabled // #347: Enable once we move away from Java 8
+    void shouldThrowIfFieldCannotBeMadeAccessible() {
+        // given
+        ConfigurationDataBuilder configDataBuilder = new ConfigurationDataBuilder();
+
+        // when
+        ConfigMeException ex = assertThrows(ConfigMeException.class,
+            () -> configDataBuilder.setFieldAccessibleIfNeeded(Integer.class.getDeclaredField("digits")));
+
+        // then
+        assertThat(ex.getMessage(), equalTo("Failed to modify access for field 'digits' from class 'Integer'"));
+        assertThat(ex.getCause(), notNullValue()); // instanceOf(InaccessibleObjectException.class)
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/samples/ClassWithPrivatePropertyField.java
+++ b/src/test/java/ch/jalu/configme/samples/ClassWithPrivatePropertyField.java
@@ -8,4 +8,8 @@ import static ch.jalu.configme.properties.PropertyInitializer.newProperty;
 public class ClassWithPrivatePropertyField implements SettingsHolder {
 
     private static final Property<Integer> PRIVATE_INT_PROPERTY = newProperty("int", 4);
+
+    public static Property<Integer> getPrivatePropertyValue() {
+        return PRIVATE_INT_PROPERTY;
+    }
 }


### PR DESCRIPTION
- Use Field#setAccessible if a field is not private to make the code compatible with Kotlin constants without the need of the JvmField annotation.