### PR TITLE
Refactor RegexProperty to use a property type.

### DIFF
--- a/src/main/java/ch/jalu/configme/beanmapper/leafvaluehandler/LeafValueHandlerImpl.java
+++ b/src/main/java/ch/jalu/configme/beanmapper/leafvaluehandler/LeafValueHandlerImpl.java
@@ -5,6 +5,7 @@ import ch.jalu.configme.beanmapper.context.MappingContext;
 import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
 import ch.jalu.configme.properties.types.BooleanType;
 import ch.jalu.configme.properties.types.NumberType;
+import ch.jalu.configme.properties.types.RegexType;
 import ch.jalu.configme.properties.types.StringType;
 import ch.jalu.typeresolver.TypeInfo;
 import org.jetbrains.annotations.NotNull;
@@ -72,7 +73,8 @@ public class LeafValueHandlerImpl implements LeafValueHandler {
                 NumberType.BYTE,
                 NumberType.SHORT,
                 NumberType.BIG_INTEGER,
-                NumberType.BIG_DECIMAL)
+                NumberType.BIG_DECIMAL,
+                RegexType.REGEX)
             .collect(Collectors.toCollection(ArrayList::new));
     }
 

--- a/src/main/java/ch/jalu/configme/properties/RegexProperty.java
+++ b/src/main/java/ch/jalu/configme/properties/RegexProperty.java
@@ -1,19 +1,16 @@
 package ch.jalu.configme.properties;
 
 import ch.jalu.configme.SettingsManager;
-import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
-import ch.jalu.configme.resource.PropertyReader;
+import ch.jalu.configme.properties.types.RegexType;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 /**
  * Property whose value is a regex pattern.
  */
-public class RegexProperty extends BaseProperty<Pattern> {
+public class RegexProperty extends TypeBasedProperty<Pattern> {
 
     /**
      * Constructor.
@@ -22,7 +19,7 @@ public class RegexProperty extends BaseProperty<Pattern> {
      * @param defaultValue the default value of the property
      */
     public RegexProperty(@NotNull String path, @NotNull Pattern defaultValue) {
-        super(path, defaultValue);
+        super(path, defaultValue, RegexType.REGEX);
     }
 
     /**
@@ -33,24 +30,6 @@ public class RegexProperty extends BaseProperty<Pattern> {
      */
     public RegexProperty(@NotNull String path, @NotNull String defaultRegexValue) {
         this(path, Pattern.compile(defaultRegexValue));
-    }
-
-    @Override
-    protected @Nullable Pattern getFromReader(@NotNull PropertyReader reader,
-                                              @NotNull ConvertErrorRecorder errorRecorder) {
-        String pattern = reader.getString(getPath());
-        if (pattern != null) {
-            try {
-                return Pattern.compile(pattern);
-            } catch (PatternSyntaxException ignored) {
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public @NotNull Object toExportValue(@NotNull Pattern value) {
-        return value.pattern();
     }
 
     /**

--- a/src/main/java/ch/jalu/configme/properties/types/RegexType.java
+++ b/src/main/java/ch/jalu/configme/properties/types/RegexType.java
@@ -1,0 +1,50 @@
+package ch.jalu.configme.properties.types;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
+import ch.jalu.typeresolver.TypeInfo;
+import ch.jalu.typeresolver.primitives.PrimitiveType;
+
+/**
+ * Property type and mapper leaf type for regex.
+ */
+public class RegexType extends PropertyAndLeafType<Pattern> {
+    
+    /** Default regex type. */
+    public static final RegexType REGEX = new RegexType();
+
+    /**
+     * Constructor. Use {@link RegexType#REGEX} for the standard behaviour.
+     */
+    protected RegexType() {
+        super(Pattern.class);
+    }
+
+    @Override
+    public @Nullable Pattern convert(@Nullable Object object, @NotNull ConvertErrorRecorder errorRecorder) {
+        if (object != null && object instanceof String) {
+            String pattern = (String) object;
+            try {
+                return Pattern.compile(pattern);
+            } catch (PatternSyntaxException ignored) {
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable Object toExportValue(@NotNull Pattern value) {
+        return value.pattern();
+    }
+
+    @Override
+    public boolean canConvertToType(@NotNull TypeInfo typeInformation) {
+        Class<?> requestedClass = PrimitiveType.toReferenceType(typeInformation.toClass());
+        return requestedClass != null && requestedClass.isAssignableFrom(Pattern.class);
+    }
+}

--- a/src/main/java/ch/jalu/configme/properties/types/RegexType.java
+++ b/src/main/java/ch/jalu/configme/properties/types/RegexType.java
@@ -7,8 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
-import ch.jalu.typeresolver.TypeInfo;
-import ch.jalu.typeresolver.primitives.PrimitiveType;
 
 /**
  * Property type and mapper leaf type for regex.
@@ -19,7 +17,7 @@ public class RegexType extends PropertyAndLeafType<Pattern> {
     public static final RegexType REGEX = new RegexType();
 
     /**
-     * Constructor. Use {@link RegexType#REGEX} for the standard behaviour.
+     * Constructor. Use {@link RegexType#REGEX} for the standard behavior.
      */
     protected RegexType() {
         super(Pattern.class);
@@ -27,7 +25,7 @@ public class RegexType extends PropertyAndLeafType<Pattern> {
 
     @Override
     public @Nullable Pattern convert(@Nullable Object object, @NotNull ConvertErrorRecorder errorRecorder) {
-        if (object != null && object instanceof String) {
+        if (object instanceof String) {
             String pattern = (String) object;
             try {
                 return Pattern.compile(pattern);
@@ -42,9 +40,4 @@ public class RegexType extends PropertyAndLeafType<Pattern> {
         return value.pattern();
     }
 
-    @Override
-    public boolean canConvertToType(@NotNull TypeInfo typeInformation) {
-        Class<?> requestedClass = PrimitiveType.toReferenceType(typeInformation.toClass());
-        return requestedClass != null && requestedClass.isAssignableFrom(Pattern.class);
-    }
 }

--- a/src/test/java/ch/jalu/configme/beanmapper/leafvaluehandler/LeafValueHandlerImplTest.java
+++ b/src/test/java/ch/jalu/configme/beanmapper/leafvaluehandler/LeafValueHandlerImplTest.java
@@ -7,6 +7,7 @@ import ch.jalu.configme.beanmapper.context.MappingContextImpl;
 import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
 import ch.jalu.configme.properties.types.BooleanType;
 import ch.jalu.configme.properties.types.NumberType;
+import ch.jalu.configme.properties.types.RegexType;
 import ch.jalu.configme.properties.types.StringType;
 import ch.jalu.typeresolver.typeimpl.WildcardTypeImpl;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,7 @@ class LeafValueHandlerImplTest {
         List<MapperLeafType> leafTypes = LeafValueHandlerImpl.createDefaultLeafTypes();
 
         // then
-        assertThat(leafTypes, hasSize(11));
+        assertThat(leafTypes, hasSize(12));
         assertThat(leafTypes.get(0), sameInstance(BooleanType.BOOLEAN));
         assertThat(leafTypes.get(1), sameInstance(StringType.STRING));
         assertThat(leafTypes.get(2), sameInstance(NumberType.INTEGER));
@@ -67,6 +68,7 @@ class LeafValueHandlerImplTest {
         assertThat(leafTypes.get(8), sameInstance(NumberType.SHORT));
         assertThat(leafTypes.get(9), sameInstance(NumberType.BIG_INTEGER));
         assertThat(leafTypes.get(10), sameInstance(NumberType.BIG_DECIMAL));
+        assertThat(leafTypes.get(11), sameInstance(RegexType.REGEX));
     }
 
     @Test
@@ -96,12 +98,13 @@ class LeafValueHandlerImplTest {
 
         // then
         List<MapperLeafType> leafTypes = valueHandler.getLeafTypes();
-        assertThat(leafTypes, hasSize(5));
+        assertThat(leafTypes, hasSize(6));
         assertThat(leafTypes.get(0), sameInstance(leafType1));
         assertThat(leafTypes.get(1), sameInstance(BooleanType.BOOLEAN));
         assertThat(leafTypes.get(2), sameInstance(StringType.STRING));
         assertThat(leafTypes.get(3), instanceOf(EnumLeafType.class));
-        assertThat(leafTypes.get(4), sameInstance(leafType2));
+        assertThat(leafTypes.get(4), sameInstance(RegexType.REGEX));
+        assertThat(leafTypes.get(5), sameInstance(leafType2));
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/RegexPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/RegexPropertyTest.java
@@ -35,7 +35,7 @@ class RegexPropertyTest {
         // given
         RegexProperty property = new RegexProperty("names.whitelist", "s_.*?");
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getString("names.whitelist")).willReturn("m[0-9]+");
+        given(reader.getObject("names.whitelist")).willReturn("m[0-9]+");
         ConvertErrorRecorder convertErrorRecorder = new ConvertErrorRecorder();
 
         // when

--- a/src/test/java/ch/jalu/configme/properties/types/RegexTypeTest.java
+++ b/src/test/java/ch/jalu/configme/properties/types/RegexTypeTest.java
@@ -1,0 +1,98 @@
+package ch.jalu.configme.properties.types;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
+
+import static ch.jalu.typeresolver.TypeInfo.of;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test for {@link RegexType}.
+ */
+public class RegexTypeTest {
+
+    @Test
+    void shouldSupportPatternClassesAndParentsOnly() {
+        // given / when / then
+        assertTrue(RegexType.REGEX.canConvertToType(of(Pattern.class)));
+        assertTrue(RegexType.REGEX.canConvertToType(of(Serializable.class)));
+        assertTrue(RegexType.REGEX.canConvertToType(of(Object.class)));
+
+        assertFalse(RegexType.REGEX.canConvertToType(of(String.class)));
+        assertFalse(RegexType.REGEX.canConvertToType(of(Integer.class)));
+        assertFalse(RegexType.REGEX.canConvertToType(of(List.class)));
+        assertFalse(RegexType.REGEX.canConvertToType(of(boolean[].class)));
+        assertFalse(RegexType.REGEX.canConvertToType(of(Date.class)));
+    }
+
+    @Test
+    void shouldConvertForValidRegex() {
+        // given
+        ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
+
+        // then / when
+        assertInstanceOf(Pattern.class, RegexType.REGEX.convert("s_.*?", errorRecorder));
+        assertInstanceOf(Pattern.class, RegexType.REGEX.convert("\\s*", errorRecorder));
+        assertInstanceOf(Pattern.class, RegexType.REGEX.convert("Hello", errorRecorder));
+        assertInstanceOf(Pattern.class, RegexType.REGEX.convert("$", errorRecorder));
+    }
+
+    @Test
+    void shouldReturnNullForInvalidRegex() {
+        // given
+        ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
+
+        // when / then
+        assertThat(RegexType.REGEX.convert("[abc", errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert("(", errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert("[a-z", errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert("a{,3}", errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert("{2,1}", errorRecorder), nullValue());
+    }
+
+    @Test
+    void shouldReturnNullForNull() {
+        // given
+        ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
+
+        // when / then
+        assertThat(RegexType.REGEX.convert(null, errorRecorder), nullValue());
+    }
+
+    @Test
+    void shouldReturnNullForUnsupportedTypes() {
+        // given
+        ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
+
+        // when / then
+        assertThat(RegexType.REGEX.convert(3, of(Pattern.class), errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert(1, of(Pattern.class), errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert('c', of(Pattern.class), errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert(false, of(Pattern.class), errorRecorder), nullValue());
+        assertThat(RegexType.REGEX.convert(TimeUnit.SECONDS, of(Pattern.class), errorRecorder), nullValue());
+    }
+
+    @Test
+    void shouldExportValueAsString() {
+        // given 
+        Pattern pattern1 = Pattern.compile("#\\w+");
+        Pattern pattern2 = Pattern.compile("^[A-Za-z]+$");
+    
+        // when / then
+        assertThat(RegexType.REGEX.toExportValue(pattern1), equalTo("#\\w+"));
+        assertThat(RegexType.REGEX.toExportValue(pattern2), equalTo("^[A-Za-z]+$"));
+    }
+}


### PR DESCRIPTION
### Change Log
- Created class `RegexType` extending from `PropertyAndLeafType`.
- Conversion logic moved from the `RegexProperty` to the new type.
- Changed `RegexProperty` to extend `TypeBasedProperty` and to use the `RegexType`.
- Added `RegexType` to the list of default types in the leaf value handler.
- Fixed broken unit test cases because of the above changes.
- Added unit test cases for `RegexType`.