### PR TITLE
Throw if a new comment overwrites an existing comment path.

### DIFF
--- a/src/main/java/ch/jalu/configme/configurationdata/CommentsConfiguration.java
+++ b/src/main/java/ch/jalu/configme/configurationdata/CommentsConfiguration.java
@@ -43,8 +43,8 @@ public class CommentsConfiguration {
     public void setComment(@NotNull String path, @NotNull String... commentLines) {
         List<String> replaced = comments.put(path, Collections.unmodifiableList(Arrays.asList(commentLines)));
         
-        if(replaced != null) {
-            throw new IllegalStateException("Comment lines already exists for the path " + path);
+        if (replaced != null) {
+            throw new IllegalStateException("Comment lines already exists for the path '" + path + "'");
         }
     }
 

--- a/src/main/java/ch/jalu/configme/configurationdata/CommentsConfiguration.java
+++ b/src/main/java/ch/jalu/configme/configurationdata/CommentsConfiguration.java
@@ -41,7 +41,11 @@ public class CommentsConfiguration {
      * @param commentLines the comment lines to set for the path
      */
     public void setComment(@NotNull String path, @NotNull String... commentLines) {
-        comments.put(path, Collections.unmodifiableList(Arrays.asList(commentLines)));
+        List<String> replaced = comments.put(path, Collections.unmodifiableList(Arrays.asList(commentLines)));
+        
+        if(replaced != null) {
+            throw new IllegalStateException("Comment lines already exists for the path " + path);
+        }
     }
 
     /**

--- a/src/test/java/ch/jalu/configme/configurationdata/CommentsConfigurationTest.java
+++ b/src/test/java/ch/jalu/configme/configurationdata/CommentsConfigurationTest.java
@@ -11,11 +11,30 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for {@link CommentsConfiguration}.
  */
 class CommentsConfigurationTest {
+
+    @Test
+    void shouldThrowForExistingPath() {
+        // given
+        final String path = "config.me"; 
+        CommentsConfiguration conf = new CommentsConfiguration();
+        conf.setComment(path, "Old", "Comments", "1", "2", "3");
+        
+        // when
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> conf.setComment(path, "New Comment"));
+
+        // then
+        assertThat(ex.getMessage(), equalTo("Comment lines already exists for the path " + path));
+        assertEquals(conf.getAllComments().size(), 1);
+        assertEquals(conf.getAllComments().get(path).size(), 1);
+        assertThat(conf.getAllComments().get(path), contains("New Comment"));
+    }
 
     @Test
     void shouldOverrideExistingComment() {
@@ -25,9 +44,11 @@ class CommentsConfigurationTest {
         conf.setComment("other.path", "Some other", "path I am", "adding");
 
         // when
-        conf.setComment("com.acme", "Acme new comment", "1, 2, 3");
+        IllegalStateException ex = assertThrows(IllegalStateException.class, ()-> conf.setComment("com.acme", "Acme new comment", "1, 2, 3"));
 
         // then
+        assertThat(ex.getMessage(), equalTo("Comment lines already exists for the path com.acme"));
+
         Map<String, List<String>> allComments = conf.getAllComments();
         assertThat(allComments.keySet(), containsInAnyOrder("com.acme", "other.path"));
         assertThat(allComments.get("com.acme"), contains("Acme new comment", "1, 2, 3"));

--- a/src/test/java/ch/jalu/configme/configurationdata/CommentsConfigurationTest.java
+++ b/src/test/java/ch/jalu/configme/configurationdata/CommentsConfigurationTest.java
@@ -29,7 +29,7 @@ class CommentsConfigurationTest {
         IllegalStateException ex = assertThrows(IllegalStateException.class, () -> conf.setComment(path, "New Comment"));
 
         // then
-        assertThat(ex.getMessage(), equalTo("Comment lines already exists for the path " + path));
+        assertThat(ex.getMessage(), equalTo("Comment lines already exists for the path 'config.me'"));
         assertThat(conf.getAllComments().keySet(), contains(path));
         assertThat(conf.getAllComments().get(path), contains("New Comment"));
     }
@@ -45,7 +45,7 @@ class CommentsConfigurationTest {
         IllegalStateException ex = assertThrows(IllegalStateException.class, ()-> conf.setComment("com.acme", "Acme new comment", "1, 2, 3"));
 
         // then
-        assertThat(ex.getMessage(), equalTo("Comment lines already exists for the path com.acme"));
+        assertThat(ex.getMessage(), equalTo("Comment lines already exists for the path 'com.acme'"));
 
         Map<String, List<String>> allComments = conf.getAllComments();
         assertThat(allComments.keySet(), containsInAnyOrder("com.acme", "other.path"));

--- a/src/test/java/ch/jalu/configme/configurationdata/CommentsConfigurationTest.java
+++ b/src/test/java/ch/jalu/configme/configurationdata/CommentsConfigurationTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -31,8 +30,7 @@ class CommentsConfigurationTest {
 
         // then
         assertThat(ex.getMessage(), equalTo("Comment lines already exists for the path " + path));
-        assertEquals(conf.getAllComments().size(), 1);
-        assertEquals(conf.getAllComments().get(path).size(), 1);
+        assertThat(conf.getAllComments().keySet(), contains(path));
         assertThat(conf.getAllComments().get(path), contains("New Comment"));
     }
 


### PR DESCRIPTION
### Change Log
- Throw an exception if a comment is registered to a path that already has comments.
- Fixed broken unit test case because of the change.
- Added new unit test case covering the change.