### PR TITLE
Refactor Utils Classes

### DIFF
--- a/src/main/java/ch/jalu/configme/SettingsManagerBuilder.java
+++ b/src/main/java/ch/jalu/configme/SettingsManagerBuilder.java
@@ -7,7 +7,7 @@ import ch.jalu.configme.migration.PlainMigrationService;
 import ch.jalu.configme.resource.PropertyResource;
 import ch.jalu.configme.resource.YamlFileResource;
 import ch.jalu.configme.resource.YamlFileResourceOptions;
-import ch.jalu.configme.utils.Utils;
+import ch.jalu.configme.utils.FileUtils;
 import org.jetbrains.annotations.NotNull;
 
 import org.jetbrains.annotations.Nullable;
@@ -57,7 +57,7 @@ public final class SettingsManagerBuilder {
      */
     public static @NotNull SettingsManagerBuilder withYamlFile(@NotNull Path path,
                                                                @NotNull YamlFileResourceOptions resourceOptions) {
-        Utils.createFileIfNotExists(path);
+        FileUtils.createFileIfNotExists(path);
         return new SettingsManagerBuilder(new YamlFileResource(path, resourceOptions));
     }
 

--- a/src/main/java/ch/jalu/configme/beanmapper/MapperImpl.java
+++ b/src/main/java/ch/jalu/configme/beanmapper/MapperImpl.java
@@ -17,6 +17,10 @@ import ch.jalu.typeresolver.TypeInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static ch.jalu.configme.internal.PathUtils.OPTIONAL_SPECIFIER;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForIndex;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForMapKey;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -25,10 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-
-import static ch.jalu.configme.utils.PathUtils.OPTIONAL_SPECIFIER;
-import static ch.jalu.configme.utils.PathUtils.pathSpecifierForIndex;
-import static ch.jalu.configme.utils.PathUtils.pathSpecifierForMapKey;
 
 /**
  * Implementation of {@link Mapper}.

--- a/src/main/java/ch/jalu/configme/beanmapper/MapperImpl.java
+++ b/src/main/java/ch/jalu/configme/beanmapper/MapperImpl.java
@@ -17,10 +17,6 @@ import ch.jalu.typeresolver.TypeInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static ch.jalu.configme.internal.PathUtils.OPTIONAL_SPECIFIER;
-import static ch.jalu.configme.internal.PathUtils.pathSpecifierForIndex;
-import static ch.jalu.configme.internal.PathUtils.pathSpecifierForMapKey;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -29,6 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+
+import static ch.jalu.configme.internal.PathUtils.OPTIONAL_SPECIFIER;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForIndex;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForMapKey;
 
 /**
  * Implementation of {@link Mapper}.

--- a/src/main/java/ch/jalu/configme/beanmapper/context/ExportContextImpl.java
+++ b/src/main/java/ch/jalu/configme/beanmapper/context/ExportContextImpl.java
@@ -1,7 +1,8 @@
 package ch.jalu.configme.beanmapper.context;
 
 import ch.jalu.configme.beanmapper.propertydescription.BeanPropertyComments;
-import ch.jalu.configme.utils.PathUtils;
+import ch.jalu.configme.internal.PathUtils;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;

--- a/src/main/java/ch/jalu/configme/beanmapper/context/MappingContextImpl.java
+++ b/src/main/java/ch/jalu/configme/beanmapper/context/MappingContextImpl.java
@@ -1,7 +1,7 @@
 package ch.jalu.configme.beanmapper.context;
 
+import ch.jalu.configme.internal.PathUtils;
 import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
-import ch.jalu.configme.utils.PathUtils;
 import ch.jalu.typeresolver.TypeInfo;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/ch/jalu/configme/internal/PathUtils.java
+++ b/src/main/java/ch/jalu/configme/internal/PathUtils.java
@@ -1,4 +1,4 @@
-package ch.jalu.configme.utils;
+package ch.jalu.configme.internal;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/ch/jalu/configme/internal/StreamUtils.java
+++ b/src/main/java/ch/jalu/configme/internal/StreamUtils.java
@@ -1,4 +1,4 @@
-package ch.jalu.configme.utils;
+package ch.jalu.configme.internal;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
+++ b/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
@@ -1,7 +1,8 @@
 package ch.jalu.configme.resource;
 
 import ch.jalu.configme.exception.ConfigMeException;
-import ch.jalu.configme.utils.PathUtils;
+import ch.jalu.configme.internal.PathUtils;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.Yaml;

--- a/src/main/java/ch/jalu/configme/resource/YamlFileResource.java
+++ b/src/main/java/ch/jalu/configme/resource/YamlFileResource.java
@@ -2,13 +2,14 @@ package ch.jalu.configme.resource;
 
 import ch.jalu.configme.configurationdata.ConfigurationData;
 import ch.jalu.configme.exception.ConfigMeException;
+import ch.jalu.configme.internal.StreamUtils;
 import ch.jalu.configme.properties.Property;
 import ch.jalu.configme.resource.PropertyPathTraverser.PathElement;
 import ch.jalu.configme.resource.yaml.SnakeYamlNodeBuilder;
 import ch.jalu.configme.resource.yaml.SnakeYamlNodeBuilderImpl;
 import ch.jalu.configme.resource.yaml.SnakeYamlNodeContainer;
 import ch.jalu.configme.resource.yaml.SnakeYamlNodeContainerImpl;
-import ch.jalu.configme.utils.StreamUtils;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.DumperOptions;

--- a/src/main/java/ch/jalu/configme/resource/yaml/SnakeYamlNodeBuilderImpl.java
+++ b/src/main/java/ch/jalu/configme/resource/yaml/SnakeYamlNodeBuilderImpl.java
@@ -15,10 +15,6 @@ import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import static ch.jalu.configme.internal.PathUtils.concatSpecifierAware;
-import static ch.jalu.configme.internal.PathUtils.pathSpecifierForIndex;
-import static ch.jalu.configme.internal.PathUtils.pathSpecifierForMapKey;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +29,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static ch.jalu.configme.internal.PathUtils.concatSpecifierAware;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForIndex;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForMapKey;
 
 /**
  * Default implementation of {@link SnakeYamlNodeBuilder}: creates SnakeYAML nodes for values and comments.

--- a/src/main/java/ch/jalu/configme/resource/yaml/SnakeYamlNodeBuilderImpl.java
+++ b/src/main/java/ch/jalu/configme/resource/yaml/SnakeYamlNodeBuilderImpl.java
@@ -1,8 +1,9 @@
 package ch.jalu.configme.resource.yaml;
 
 import ch.jalu.configme.configurationdata.ConfigurationData;
+import ch.jalu.configme.internal.StreamUtils;
 import ch.jalu.configme.properties.convertresult.ValueWithComments;
-import ch.jalu.configme.utils.StreamUtils;
+
 import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.comments.CommentLine;
@@ -13,6 +14,10 @@ import org.yaml.snakeyaml.nodes.NodeTuple;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
+
+import static ch.jalu.configme.internal.PathUtils.concatSpecifierAware;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForIndex;
+import static ch.jalu.configme.internal.PathUtils.pathSpecifierForMapKey;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -28,10 +33,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import static ch.jalu.configme.utils.PathUtils.concatSpecifierAware;
-import static ch.jalu.configme.utils.PathUtils.pathSpecifierForIndex;
-import static ch.jalu.configme.utils.PathUtils.pathSpecifierForMapKey;
 
 /**
  * Default implementation of {@link SnakeYamlNodeBuilder}: creates SnakeYAML nodes for values and comments.

--- a/src/main/java/ch/jalu/configme/utils/FileUtils.java
+++ b/src/main/java/ch/jalu/configme/utils/FileUtils.java
@@ -8,7 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Utilities class.
+ * Class with file utilities.
  */
 public final class FileUtils {
 

--- a/src/main/java/ch/jalu/configme/utils/FileUtils.java
+++ b/src/main/java/ch/jalu/configme/utils/FileUtils.java
@@ -10,9 +10,9 @@ import java.nio.file.Path;
 /**
  * Utilities class.
  */
-public final class Utils {
+public final class FileUtils {
 
-    private Utils() {
+    private FileUtils() {
     }
 
     /**

--- a/src/test/java/ch/jalu/configme/internal/PathUtilsTest.java
+++ b/src/test/java/ch/jalu/configme/internal/PathUtilsTest.java
@@ -1,4 +1,4 @@
-package ch.jalu.configme.utils;
+package ch.jalu.configme.internal;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/ch/jalu/configme/internal/StreamUtilsTest.java
+++ b/src/test/java/ch/jalu/configme/internal/StreamUtilsTest.java
@@ -1,4 +1,4 @@
-package ch.jalu.configme.utils;
+package ch.jalu.configme.internal;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/ch/jalu/configme/utils/FileUtilsTest.java
+++ b/src/test/java/ch/jalu/configme/utils/FileUtilsTest.java
@@ -30,10 +30,10 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 /**
- * Test for {@link Utils}.
+ * Test for {@link FileUtils}.
  */
 @ExtendWith(MockitoExtension.class)
-class UtilsTest {
+class FileUtilsTest {
 
     @TempDir
     public Path temporaryFolder;
@@ -45,8 +45,8 @@ class UtilsTest {
         Path otherFile = temporaryFolder.resolve("big/path/in/middle/toFile.png");
 
         // when
-        Utils.createFileIfNotExists(file);
-        Utils.createFileIfNotExists(otherFile);
+        FileUtils.createFileIfNotExists(file);
+        FileUtils.createFileIfNotExists(otherFile);
 
         // then
         assertThat(Files.exists(file), equalTo(true));
@@ -57,7 +57,7 @@ class UtilsTest {
     void shouldThrowForFolderAsFile() {
         // given / when
         ConfigMeException ex = assertThrows(ConfigMeException.class,
-            () -> Utils.createFileIfNotExists(temporaryFolder));
+            () -> FileUtils.createFileIfNotExists(temporaryFolder));
 
         // then
         assertThat(ex.getMessage(), matchesPattern("Expected file but '.*?' is not a file"));
@@ -69,11 +69,11 @@ class UtilsTest {
         // given
         Path parent = temporaryFolder.resolve("foo");
         Path file = temporaryFolder.resolve("foo/foo.txt");
-        Utils.createFileIfNotExists(parent);
+        FileUtils.createFileIfNotExists(parent);
 
         // when
         ConfigMeException ex = assertThrows(ConfigMeException.class,
-            () -> Utils.createFileIfNotExists(file));
+            () -> FileUtils.createFileIfNotExists(file));
 
         // then
         assertThat(ex.getMessage(), matchesPattern("Failed to create parent folders for '.*?foo.txt'"));
@@ -97,7 +97,7 @@ class UtilsTest {
 
         // when
         ConfigMeException ex = assertThrows(ConfigMeException.class,
-            () -> Utils.createFileIfNotExists(child));
+            () -> FileUtils.createFileIfNotExists(child));
 
         // then
         assertThat(ex.getMessage(), matchesPattern("Failed to create file '.*?'"));


### PR DESCRIPTION
### Change Log
- Renamed `Utils` to `FileUtils` and `UtilsTest` to `FileUtilsTest`.
- Moved `StreamUtils` and `PathUtils` from `ch.jalu.configme.utils` to a new package `ch.jalu.configme.internal`.
- Moved `StreamUtilsTest` and `PathUtilsTest` from `ch.jalu.configme.utils` to a new package `ch.jalu.configme.internal`.
- Replaced the old usages of the above classes with the new ones.

Resolves: https://github.com/AuthMe/ConfigMe/issues/320