### PR TITLE
Case-insensitive pattern type

### DIFF
--- a/src/main/java/ch/jalu/configme/properties/types/RegexType.java
+++ b/src/main/java/ch/jalu/configme/properties/types/RegexType.java
@@ -16,6 +16,14 @@ public class RegexType extends PropertyAndLeafType<Pattern> {
     /** Default regex type. */
     public static final RegexType REGEX = new RegexType();
 
+    /** Case insensitive regex type. */
+    public static final RegexType REGEX_CASE_INSENSITIVE = new RegexType() {
+        @Override
+        protected @NotNull Pattern compileToPattern(@NotNull String regex) {
+            return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        }
+    };
+
     /**
      * Constructor. Use {@link RegexType#REGEX} for the standard behavior.
      */
@@ -26,9 +34,9 @@ public class RegexType extends PropertyAndLeafType<Pattern> {
     @Override
     public @Nullable Pattern convert(@Nullable Object object, @NotNull ConvertErrorRecorder errorRecorder) {
         if (object instanceof String) {
-            String pattern = (String) object;
+            String regex = (String) object;
             try {
-                return Pattern.compile(pattern);
+                return compileToPattern(regex);
             } catch (PatternSyntaxException ignored) {
             }
         }
@@ -40,4 +48,13 @@ public class RegexType extends PropertyAndLeafType<Pattern> {
         return value.pattern();
     }
 
+    /**
+     * Compiles the given string to a pattern object.
+     *
+     * @param regex the string to compile
+     * @return the pattern object
+     */
+    protected @NotNull Pattern compileToPattern(@NotNull String regex) {
+        return Pattern.compile(regex);
+    }
 }

--- a/src/test/java/ch/jalu/configme/properties/types/RegexTypeTest.java
+++ b/src/test/java/ch/jalu/configme/properties/types/RegexTypeTest.java
@@ -45,7 +45,9 @@ public class RegexTypeTest {
 
         // then / when
         assertInstanceOf(Pattern.class, RegexType.REGEX.convert("s_.*?", errorRecorder));
+        assertInstanceOf(Pattern.class, RegexType.REGEX_CASE_INSENSITIVE.convert("a_.*?", errorRecorder));
         assertInstanceOf(Pattern.class, RegexType.REGEX.convert("\\s*", errorRecorder));
+        assertInstanceOf(Pattern.class, RegexType.REGEX_CASE_INSENSITIVE.convert("\\w+", errorRecorder));
         assertInstanceOf(Pattern.class, RegexType.REGEX.convert("Hello", errorRecorder));
         assertInstanceOf(Pattern.class, RegexType.REGEX.convert("$", errorRecorder));
     }
@@ -61,6 +63,8 @@ public class RegexTypeTest {
         assertThat(RegexType.REGEX.convert("[a-z", errorRecorder), nullValue());
         assertThat(RegexType.REGEX.convert("a{,3}", errorRecorder), nullValue());
         assertThat(RegexType.REGEX.convert("{2,1}", errorRecorder), nullValue());
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.convert("a{1", errorRecorder), nullValue());
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.convert("(abc(def)ghi)jkl)", errorRecorder), nullValue());
     }
 
     @Test
@@ -70,6 +74,7 @@ public class RegexTypeTest {
 
         // when / then
         assertThat(RegexType.REGEX.convert(null, errorRecorder), nullValue());
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.convert(null, errorRecorder), nullValue());
     }
 
     @Test
@@ -79,9 +84,11 @@ public class RegexTypeTest {
 
         // when / then
         assertThat(RegexType.REGEX.convert(3, of(Pattern.class), errorRecorder), nullValue());
-        assertThat(RegexType.REGEX.convert(1, of(Pattern.class), errorRecorder), nullValue());
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.convert(1, of(Pattern.class), errorRecorder), nullValue());
         assertThat(RegexType.REGEX.convert('c', of(Pattern.class), errorRecorder), nullValue());
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.convert('x', of(Pattern.class), errorRecorder), nullValue());
         assertThat(RegexType.REGEX.convert(false, of(Pattern.class), errorRecorder), nullValue());
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.convert(true, of(Pattern.class), errorRecorder), nullValue());
         assertThat(RegexType.REGEX.convert(TimeUnit.SECONDS, of(Pattern.class), errorRecorder), nullValue());
     }
 
@@ -93,6 +100,8 @@ public class RegexTypeTest {
     
         // when / then
         assertThat(RegexType.REGEX.toExportValue(pattern1), equalTo("#\\w+"));
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.toExportValue(pattern1), equalTo("#\\w+"));
         assertThat(RegexType.REGEX.toExportValue(pattern2), equalTo("^[A-Za-z]+$"));
+        assertThat(RegexType.REGEX_CASE_INSENSITIVE.toExportValue(pattern2), equalTo("^[A-Za-z]+$"));
     }
 }


### PR DESCRIPTION
### Change Log
- Extracted the regex compilation into a new method `RegexType#compileToPattern`.
- Added a new constant regex instance in `RegexType` for case insensitive usage.
- Extended test cases for the new instance added.

Resolves: https://github.com/AuthMe/ConfigMe/issues/378