### PR TITLE
Fix readme WelcomeWriter.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ public class TitleConfig implements SettingsHolder {
 public class WelcomeWriter {
     public String generateWelcomeMessage() {
         SettingsManager settings = SettingsManagerBuilder
-            .withYamlFile("config.yml")
+            .withYamlFile(Path.of("config.yml"))
             .configurationData(TitleConfig.class)
             .useDefaultMigrationService()
             .create();


### PR DESCRIPTION
With the latest version of the library (1.4.1 at the moment)
This method doesn't support a raw String parameter
```java
SettingsManagerBuilder.withYamlFile("config.yml") // won't compile
...
```
So a Path parameter could be used instead
```java
SettingsManagerBuilder.withYamlFile(Path.of("config.yml"))
...
```