### PR TITLE
#372 Move path methods from PropertyReader to PathProvider

### DIFF
--- a/src/main/java/ch/jalu/configme/properties/TypeBasedProperty.java
+++ b/src/main/java/ch/jalu/configme/properties/TypeBasedProperty.java
@@ -32,7 +32,7 @@ public class TypeBasedProperty<T> extends BaseProperty<T> {
 
     @Override
     protected @Nullable T getFromReader(@NotNull PropertyReader reader, @NotNull ConvertErrorRecorder errorRecorder) {
-        return type.convert(reader.getObject(getPath()), errorRecorder);
+        return type.convert(reader.getValue(getPath()), errorRecorder);
     }
 
     @Override

--- a/src/main/java/ch/jalu/configme/resource/PathProvider.java
+++ b/src/main/java/ch/jalu/configme/resource/PathProvider.java
@@ -1,0 +1,55 @@
+package ch.jalu.configme.resource;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+/**
+ * Exposes the paths available in a configuration resource.
+ * <p>
+ * This interface is an optional extension for {@link PropertyReader} implementations that support path enumeration.
+ */
+public interface PathProvider {
+
+    /**
+     * Returns all paths available in the resource, including intermediate paths.
+     * <p>
+     * For a configuration like:
+     * <pre>
+     * header:
+     *   title: Hello
+     *   font:
+     *     color: red
+     *     size: 12
+     * </pre>
+     * this method returns {@code ["header", "header.title", "header.font", "header.font.color", "header.font.size"]}.
+     *
+     * @return all paths (in encounter order)
+     */
+    @NotNull Set<String> getPaths();
+
+    /**
+     * Returns all leaf paths in the resource.
+     * <p>
+     * For the configuration example in {@link #getPaths()}, this method returns
+     * {@code ["header.title", "header.font.color", "header.font.size"]}.
+     *
+     * @return all leaf paths (in encounter order)
+     */
+    @NotNull Set<String> getLeafPaths();
+
+    /**
+     * Returns the direct child paths of the given path. Returns an empty set
+     * if the path does not exist or has no children.
+     * <p>
+     * For the configuration example in {@link #getPaths()},
+     * {@code getChildPaths("header")} returns {@code ["header.title", "header.font"]}.
+     * <p>
+     * If {@code path} is empty, the top-level paths are returned.
+     *
+     * @param path the path whose direct child paths should be looked up
+     * @return all direct child paths (in encounter order, never null)
+     */
+    @NotNull Set<String> getChildPaths(@NotNull String path);
+
+}

--- a/src/main/java/ch/jalu/configme/resource/PropertyReader.java
+++ b/src/main/java/ch/jalu/configme/resource/PropertyReader.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * A property reader provides values from a resource (e.g. a YAML file) based on whose data the values of properties
@@ -36,24 +35,6 @@ public interface PropertyReader {
      * @return the value, or null if there is none
      */
     @Nullable Object getValue(@NotNull String path);
-
-    /**
-     * Returns the keys available in the file. Depending on the parameter either all keys are returned,
-     * or only the keys of the leaf nodes are considered.
-     *
-     * @param onlyLeafNodes true if only the paths of leaf nodes should be returned (no intermediate paths)
-     * @return set of all existing keys (ordered)
-     */
-    @NotNull Set<String> getKeys(boolean onlyLeafNodes);
-
-    /**
-     * Returns the direct children of the given path which are available in the file. Returns an empty set
-     * if the path does not exist in the file (never null).
-     *
-     * @param path the path whose direct child paths should be looked up
-     * @return set of all direct children (ordered, never null)
-     */
-    @NotNull Set<String> getChildKeys(@NotNull String path);
 
     /**
      * Returns the object at the given path, or null if absent.

--- a/src/main/java/ch/jalu/configme/resource/PropertyReader.java
+++ b/src/main/java/ch/jalu/configme/resource/PropertyReader.java
@@ -1,7 +1,13 @@
 package ch.jalu.configme.resource;
 
+import ch.jalu.configme.properties.BooleanProperty;
+import ch.jalu.configme.properties.DoubleProperty;
+import ch.jalu.configme.properties.IntegerProperty;
+import ch.jalu.configme.properties.StringProperty;
+import ch.jalu.configme.properties.convertresult.PropertyValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 import java.util.Set;
 
@@ -22,6 +28,14 @@ public interface PropertyReader {
      * @return true if there is a value, false otherwise
      */
     boolean contains(@NotNull String path);
+
+    /**
+     * Returns the object at the given path, or null if absent.
+     *
+     * @param path the path to retrieve the value for
+     * @return the value, or null if there is none
+     */
+    @Nullable Object getValue(@NotNull String path);
 
     /**
      * Returns the keys available in the file. Depending on the parameter either all keys are returned,
@@ -46,47 +60,85 @@ public interface PropertyReader {
      *
      * @param path the path to retrieve the value for
      * @return the value, or null if there is none
+     * @deprecated Use {@link #getValue}
      */
-    @Nullable Object getObject(@NotNull String path);
+    @Deprecated
+    default @Nullable Object getObject(@NotNull String path) {
+        return getValue(path);
+    }
 
     /**
      * Returns the value of the given path as a String if available.
      *
      * @param path the path to retrieve a String for
      * @return the value as a String, or null if not applicable or unavailable
+     * @deprecated read the value with a {@link StringProperty},
+     *             or call {@link #getValue} and perform your own casts
      */
-    @Nullable String getString(@NotNull String path);
+    @Deprecated
+    default @Nullable String getString(@NotNull String path) {
+        StringProperty strProperty = new StringProperty(path, "");
+        PropertyValue<String> value = strProperty.determineValue(this);
+        return value.isValidInResource() ? value.getValue() : null;
+    }
 
     /**
      * Returns the value of the given path as an integer if available.
      *
      * @param path the path to retrieve an integer for
      * @return the value as integer, or null if not applicable or unavailable
+     * @deprecated read the value with an {@link IntegerProperty},
+     *             or call {@link #getValue} and perform your own casts
      */
-    @Nullable Integer getInt(@NotNull String path);
+    @Deprecated
+    default @Nullable Integer getInt(@NotNull String path) {
+        IntegerProperty intProperty = new IntegerProperty(path, 0);
+        PropertyValue<Integer> value = intProperty.determineValue(this);
+        return value.isValidInResource() ? value.getValue() : null;
+    }
 
     /**
      * Returns the value of the given path as a double if available.
      *
      * @param path the path to retrieve a double for
      * @return the value as a double, or null if not applicable or unavailable
+     * @deprecated read the value with an {@link DoubleProperty},
+     *             or call {@link #getValue} and perform your own casts
      */
-    @Nullable Double getDouble(@NotNull String path);
+    @Deprecated
+    default @Nullable Double getDouble(@NotNull String path) {
+        DoubleProperty doubleProperty = new DoubleProperty(path, 0);
+        PropertyValue<Double> value = doubleProperty.determineValue(this);
+        return value.isValidInResource() ? value.getValue() : null;
+    }
 
     /**
      * Returns the value of the given path as a boolean if available.
      *
      * @param path the path to retrieve a boolean for
      * @return the value as a boolean, or null if not applicable or unavailable
+     * @deprecated read the value with a {@link BooleanProperty},
+     *             or call {@link #getValue} and perform your own casts
      */
-    @Nullable Boolean getBoolean(@NotNull String path);
+    @Deprecated
+    default @Nullable Boolean getBoolean(@NotNull String path) {
+        BooleanProperty boolProperty = new BooleanProperty(path, true);
+        PropertyValue<Boolean> value = boolProperty.determineValue(this);
+        return value.isValidInResource() ? value.getValue() : null;
+    }
 
     /**
      * Returns the value of the given path as a list if available.
      *
      * @param path the path to retrieve a list for
      * @return the value as a list, or null if not applicable or unavailable
+     * @deprecated read the value with a {@link ch.jalu.configme.properties.ListProperty ListProperty},
+     *             or call {@link #getValue} and perform your own casts
      */
-    @Nullable List<?> getList(@NotNull String path);
+    @Deprecated
+    default @Nullable List<?> getList(@NotNull String path) {
+        Object value = getValue(path);
+        return value instanceof List<?> ? (List<?>) value : null;
+    }
 
 }

--- a/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
+++ b/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
@@ -99,21 +99,21 @@ public class YamlFileReader implements PropertyReader, PathProvider {
         if (root == null) {
             return Collections.emptySet();
         }
-        Set<String> allKeys = new LinkedHashSet<>();
-        collectKeysIntoSet("", root, allKeys, onlyLeafNodes);
-        return allKeys;
+        Set<String> allPaths = new LinkedHashSet<>();
+        collectPathsIntoSet("", root, allPaths, onlyLeafNodes);
+        return allPaths;
     }
 
     /**
-     * Recursively collects keys from maps into the given set.
+     * Recursively collects keys from maps and adds them as paths to {@code result}.
      *
-     * @param path the path of the given map
+     * @param path the path to the given map
      * @param map the map to process recursively
-     * @param result set to save keys to
+     * @param result set to save paths to
      * @param onlyLeafNodes whether only leaf nodes should be added to the result set
      */
-    private static void collectKeysIntoSet(@NotNull String path, @NotNull Map<String, Object> map,
-                                           @NotNull Set<String> result, boolean onlyLeafNodes) {
+    private static void collectPathsIntoSet(@NotNull String path, @NotNull Map<String, Object> map,
+                                            @NotNull Set<String> result, boolean onlyLeafNodes) {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String childPath = PathUtils.concat(path, entry.getKey());
             if (!onlyLeafNodes || isLeafValue(entry.getValue())) {
@@ -121,7 +121,7 @@ public class YamlFileReader implements PropertyReader, PathProvider {
             }
 
             if (entry.getValue() instanceof Map) {
-                collectKeysIntoSet(childPath, (Map) entry.getValue(), result, onlyLeafNodes);
+                collectPathsIntoSet(childPath, (Map) entry.getValue(), result, onlyLeafNodes);
             }
         }
     }
@@ -159,6 +159,9 @@ public class YamlFileReader implements PropertyReader, PathProvider {
         return new MapNormalizer().normalizeMap(map);
     }
 
+    /**
+     * @return the file this reader read from
+     */
     protected final @NotNull Path getPath() {
         return path;
     }

--- a/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
+++ b/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
@@ -2,7 +2,6 @@ package ch.jalu.configme.resource;
 
 import ch.jalu.configme.exception.ConfigMeException;
 import ch.jalu.configme.internal.PathUtils;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.Yaml;
@@ -17,7 +16,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,7 +52,7 @@ public class YamlFileReader implements PropertyReader {
     }
 
     @Override
-    public @Nullable Object getObject(@NotNull String path) {
+    public @Nullable Object getValue(@NotNull String path) {
         if (path.isEmpty()) {
             return root;
         }
@@ -71,39 +69,8 @@ public class YamlFileReader implements PropertyReader {
     }
 
     @Override
-    public @Nullable String getString(@NotNull String path) {
-        return getTypedObject(path, String.class);
-    }
-
-    @Override
-    public @Nullable Integer getInt(@NotNull String path) {
-        Number n = getTypedObject(path, Number.class);
-        return (n == null)
-            ? null
-            : n.intValue();
-    }
-
-    @Override
-    public @Nullable Double getDouble(@NotNull String path) {
-        Number n = getTypedObject(path, Number.class);
-        return (n == null)
-            ? null
-            : n.doubleValue();
-    }
-
-    @Override
-    public @Nullable Boolean getBoolean(@NotNull String path) {
-        return getTypedObject(path, Boolean.class);
-    }
-
-    @Override
-    public @Nullable List<?> getList(@NotNull String path) {
-        return getTypedObject(path, List.class);
-    }
-
-    @Override
     public boolean contains(@NotNull String path) {
-        return getObject(path) != null;
+        return getValue(path) != null;
     }
 
     @Override
@@ -118,7 +85,7 @@ public class YamlFileReader implements PropertyReader {
 
     @Override
     public @NotNull Set<String> getChildKeys(@NotNull String path) {
-        Object object = getObject(path);
+        Object object = getValue(path);
         if (object instanceof Map) {
             String pathPrefix = path.isEmpty() ? "" : path + ".";
             return ((Map<String, Object>) object).keySet().stream()
@@ -194,23 +161,6 @@ public class YamlFileReader implements PropertyReader {
     @Deprecated
     protected final @Nullable Map<String, Object> getRoot() {
         return root;
-    }
-
-    /**
-     * Gets the object at the given path and safely casts it to the given class's type. Returns null
-     * if no value is available or if it cannot be cast.
-     *
-     * @param path the path to retrieve
-     * @param clazz the class to cast to
-     * @param <T> the class type
-     * @return cast value at the given path, null if not applicable
-     */
-    protected <T> @Nullable T getTypedObject(@NotNull String path, @NotNull Class<T> clazz) {
-        Object value = getObject(path);
-        if (clazz.isInstance(value)) {
-            return clazz.cast(value);
-        }
-        return null;
     }
 
     private static @Nullable Object getEntryIfIsMap(@NotNull String key, @Nullable Object value) {

--- a/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
+++ b/src/main/java/ch/jalu/configme/resource/YamlFileReader.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 /**
  * YAML file reader.
  */
-public class YamlFileReader implements PropertyReader {
+public class YamlFileReader implements PropertyReader, PathProvider {
 
     private final Path path;
     private final Charset charset;
@@ -74,17 +74,17 @@ public class YamlFileReader implements PropertyReader {
     }
 
     @Override
-    public @NotNull Set<String> getKeys(boolean onlyLeafNodes) {
-        if (root == null) {
-            return Collections.emptySet();
-        }
-        Set<String> allKeys = new LinkedHashSet<>();
-        collectKeysIntoSet("", root, allKeys, onlyLeafNodes);
-        return allKeys;
+    public @NotNull Set<String> getPaths() {
+        return collectPaths(false);
     }
 
     @Override
-    public @NotNull Set<String> getChildKeys(@NotNull String path) {
+    public @NotNull Set<String> getLeafPaths() {
+        return collectPaths(true);
+    }
+
+    @Override
+    public @NotNull Set<String> getChildPaths(@NotNull String path) {
         Object object = getValue(path);
         if (object instanceof Map) {
             String pathPrefix = path.isEmpty() ? "" : path + ".";
@@ -95,6 +95,15 @@ public class YamlFileReader implements PropertyReader {
         return Collections.emptySet();
     }
 
+    private @NotNull Set<String> collectPaths(boolean onlyLeafNodes) {
+        if (root == null) {
+            return Collections.emptySet();
+        }
+        Set<String> allKeys = new LinkedHashSet<>();
+        collectKeysIntoSet("", root, allKeys, onlyLeafNodes);
+        return allKeys;
+    }
+
     /**
      * Recursively collects keys from maps into the given set.
      *
@@ -103,8 +112,8 @@ public class YamlFileReader implements PropertyReader {
      * @param result set to save keys to
      * @param onlyLeafNodes whether only leaf nodes should be added to the result set
      */
-    private void collectKeysIntoSet(@NotNull String path, @NotNull Map<String, Object> map, @NotNull Set<String> result,
-                                    boolean onlyLeafNodes) {
+    private static void collectKeysIntoSet(@NotNull String path, @NotNull Map<String, Object> map,
+                                           @NotNull Set<String> result, boolean onlyLeafNodes) {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String childPath = PathUtils.concat(path, entry.getKey());
             if (!onlyLeafNodes || isLeafValue(entry.getValue())) {

--- a/src/test/java/ch/jalu/configme/beanmapper/BeanWithFinalFieldsTest.java
+++ b/src/test/java/ch/jalu/configme/beanmapper/BeanWithFinalFieldsTest.java
@@ -26,7 +26,7 @@ class BeanWithFinalFieldsTest {
         // given
         BeanProperty<BeanWithFinalField> property = new BeanProperty<>("", BeanWithFinalField.class, new BeanWithFinalField());
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("")).willReturn(newMapWithName("t"));
+        given(reader.getValue("")).willReturn(newMapWithName("t"));
 
         // when
         ConfigMeException ex = assertThrows(ConfigMeException.class, () -> property.determineValue(reader));
@@ -41,7 +41,7 @@ class BeanWithFinalFieldsTest {
         BeanProperty<BeanWithFinalTransientField> property =
             new BeanProperty<>("", BeanWithFinalTransientField.class, new BeanWithFinalTransientField());
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("")).willReturn(newMapWithName("Zoran"));
+        given(reader.getValue("")).willReturn(newMapWithName("Zoran"));
 
         // when
         PropertyValue<BeanWithFinalTransientField> value = property.determineValue(reader);
@@ -56,7 +56,7 @@ class BeanWithFinalFieldsTest {
         BeanProperty<BeanWithFinalIgnoredField> property =
             new BeanProperty<>("", BeanWithFinalIgnoredField.class, new BeanWithFinalIgnoredField());
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("")).willReturn(newMapWithName("Goran"));
+        given(reader.getValue("")).willReturn(newMapWithName("Goran"));
 
         // when
         PropertyValue<BeanWithFinalIgnoredField> value = property.determineValue(reader);
@@ -71,7 +71,7 @@ class BeanWithFinalFieldsTest {
         BeanProperty<BeanWithFinalOverriddenField> property =
             new BeanProperty<>("", BeanWithFinalOverriddenField.class, new BeanWithFinalOverriddenField());
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("")).willReturn(newMapWithName("Bojan"));
+        given(reader.getValue("")).willReturn(newMapWithName("Bojan"));
 
         // when
         PropertyValue<BeanWithFinalOverriddenField> value = property.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/beanmapper/MapperImplTest.java
+++ b/src/test/java/ch/jalu/configme/beanmapper/MapperImplTest.java
@@ -82,7 +82,7 @@ class MapperImplTest {
 
         // when
         WorldGroupConfig result =
-            mapper.convertToBean(reader.getObject(""), WorldGroupConfig.class, errorRecorder);
+            mapper.convertToBean(reader.getValue(""), WorldGroupConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(true));
@@ -104,7 +104,7 @@ class MapperImplTest {
 
         // when
         CommandConfig config =
-            mapper.convertToBean(reader.getObject("commandconfig"), CommandConfig.class, errorRecorder);
+            mapper.convertToBean(reader.getValue("commandconfig"), CommandConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(false));
@@ -139,7 +139,7 @@ class MapperImplTest {
 
         // when
         WorldGroupConfig config = mapper.convertToBean(
-            reader.getObject(""), WorldGroupConfig.class, errorRecorder);
+            reader.getValue(""), WorldGroupConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(false));
@@ -154,7 +154,7 @@ class MapperImplTest {
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
 
         // when
-        CommandConfig config = mapper.convertToBean(reader.getObject("commandconfig"), CommandConfig.class, errorRecorder);
+        CommandConfig config = mapper.convertToBean(reader.getValue("commandconfig"), CommandConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(false));
@@ -185,7 +185,7 @@ class MapperImplTest {
 
         // when
         ConfigMeMapperException ex = assertThrows(ConfigMeMapperException.class,
-            () -> mapper.convertToBean(reader.getObject(""), MapWithNonStringKeys.class, new ConvertErrorRecorder()));
+            () -> mapper.convertToBean(reader.getValue(""), MapWithNonStringKeys.class, new ConvertErrorRecorder()));
 
         // then
         assertThat(ex.getMessage(), equalTo(
@@ -200,7 +200,7 @@ class MapperImplTest {
 
         // when
         ConfigMeMapperException ex = assertThrows(ConfigMeMapperException.class,
-            () -> mapper.convertToBean(reader.getObject(""), UnsupportedCollection.class, new ConvertErrorRecorder()));
+            () -> mapper.convertToBean(reader.getValue(""), UnsupportedCollection.class, new ConvertErrorRecorder()));
 
         // then
         assertThat(ex.getMessage(),
@@ -214,7 +214,7 @@ class MapperImplTest {
 
         // when
         ConfigMeMapperException ex = assertThrows(ConfigMeMapperException.class,
-            () -> mapper.convertToBean(reader.getObject(""), UntypedCollection.class, new ConvertErrorRecorder()));
+            () -> mapper.convertToBean(reader.getValue(""), UntypedCollection.class, new ConvertErrorRecorder()));
 
         // then
         assertThat(ex.getMessage(),
@@ -228,7 +228,7 @@ class MapperImplTest {
 
         // when
         ConfigMeMapperException ex = assertThrows(ConfigMeMapperException.class,
-            () -> mapper.convertToBean(reader.getObject(""), UntypedMap.class, new ConvertErrorRecorder()));
+            () -> mapper.convertToBean(reader.getValue(""), UntypedMap.class, new ConvertErrorRecorder()));
 
         // then
         assertThat(ex.getMessage(),
@@ -242,7 +242,7 @@ class MapperImplTest {
 
         // when
         ConfigMeMapperException ex = assertThrows(ConfigMeMapperException.class,
-            () -> mapper.convertToBean(reader.getObject(""), GenericCollection.class, new ConvertErrorRecorder()));
+            () -> mapper.convertToBean(reader.getValue(""), GenericCollection.class, new ConvertErrorRecorder()));
 
         // then
         assertThat(ex.getMessage(),
@@ -285,7 +285,7 @@ class MapperImplTest {
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
 
         // when
-        CommandConfig result = mapper.convertToBean(reader.getObject("commandconfig"), CommandConfig.class, errorRecorder);
+        CommandConfig result = mapper.convertToBean(reader.getValue("commandconfig"), CommandConfig.class, errorRecorder);
 
         // then
         assertThat(result, nullValue());
@@ -298,7 +298,7 @@ class MapperImplTest {
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
 
         // when
-        CommandConfig result = mapper.convertToBean(reader.getObject("commands"), CommandConfig.class, errorRecorder);
+        CommandConfig result = mapper.convertToBean(reader.getValue("commands"), CommandConfig.class, errorRecorder);
 
         // then
         assertThat(result, nullValue());
@@ -312,7 +312,7 @@ class MapperImplTest {
 
         // when
         ComplexCommandConfig result =
-            mapper.convertToBean(reader.getObject("commandconfig"), ComplexCommandConfig.class, errorRecorder);
+            mapper.convertToBean(reader.getValue("commandconfig"), ComplexCommandConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(false)); // e.g. save.arguments are missing
@@ -331,7 +331,7 @@ class MapperImplTest {
 
         // when
         ComplexCommandConfig result = mapper.convertToBean(
-            reader.getObject("commandconfig"), ComplexCommandConfig.class, errorRecorder);
+            reader.getValue("commandconfig"), ComplexCommandConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(false));
@@ -371,7 +371,7 @@ class MapperImplTest {
 
         // when
         ComplexOptionalTypeConfig result =
-            mapper.convertToBean(reader.getObject(""), ComplexOptionalTypeConfig.class, errorRecorder);
+            mapper.convertToBean(reader.getValue(""), ComplexOptionalTypeConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(true));
@@ -388,7 +388,7 @@ class MapperImplTest {
 
         // when
         ComplexOptionalTypeConfig result =
-            mapper.convertToBean(reader.getObject(""), ComplexOptionalTypeConfig.class, errorRecorder);
+            mapper.convertToBean(reader.getValue(""), ComplexOptionalTypeConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(true));
@@ -405,7 +405,7 @@ class MapperImplTest {
 
         // when
         ComplexOptionalTypeConfig result =
-            mapper.convertToBean(reader.getObject(""), ComplexOptionalTypeConfig.class, errorRecorder);
+            mapper.convertToBean(reader.getValue(""), ComplexOptionalTypeConfig.class, errorRecorder);
 
         // then
         assertThat(errorRecorder.isFullyValid(), equalTo(true));
@@ -422,7 +422,7 @@ class MapperImplTest {
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
 
         // when
-        Instant result = mapper.convertToBean(reader.getObject(""), Instant.class, errorRecorder);
+        Instant result = mapper.convertToBean(reader.getValue(""), Instant.class, errorRecorder);
 
         // then
         assertThat(result, nullValue());

--- a/src/test/java/ch/jalu/configme/beanmapper/MapperTypeResolutionTest.java
+++ b/src/test/java/ch/jalu/configme/beanmapper/MapperTypeResolutionTest.java
@@ -130,7 +130,7 @@ class MapperTypeResolutionTest {
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
 
         // when
-        RecursiveBean<TimeUnit> result = beanPropertyType.convert(reader.getObject(""), errorRecorder);
+        RecursiveBean<TimeUnit> result = beanPropertyType.convert(reader.getValue(""), errorRecorder);
 
         // then
         assertThat(result, notNullValue());

--- a/src/test/java/ch/jalu/configme/migration/version/VersionMigrationServiceTest.java
+++ b/src/test/java/ch/jalu/configme/migration/version/VersionMigrationServiceTest.java
@@ -43,7 +43,7 @@ class VersionMigrationServiceTest {
         VersionMigrationService migrationService = new VersionMigrationService(versionProperty, migration1To2, migration2To3);
 
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(versionProperty.getPath())).willReturn(3);
+        given(reader.getValue(versionProperty.getPath())).willReturn(3);
         ConfigurationData configurationData = mock(ConfigurationData.class);
 
         // when
@@ -66,7 +66,7 @@ class VersionMigrationServiceTest {
         VersionMigrationService migrationService = new VersionMigrationService(versionProperty, migration1To2, migration2To3);
 
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(versionProperty.getPath())).willReturn(3);
+        given(reader.getValue(versionProperty.getPath())).willReturn(3);
         ConfigurationData configurationData = mock(ConfigurationData.class);
         given(configurationData.areAllValuesValidInResource()).willReturn(false); // <-- Invalid value; resave expected.
 
@@ -90,7 +90,7 @@ class VersionMigrationServiceTest {
         VersionMigrationService migrationService = new VersionMigrationService(versionProperty, migration1To3, migration2To3);
 
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(versionProperty.getPath())).willReturn(1);
+        given(reader.getValue(versionProperty.getPath())).willReturn(1);
         ConfigurationData configurationData = mock(ConfigurationData.class);
 
         // when
@@ -116,7 +116,7 @@ class VersionMigrationServiceTest {
             migration1To2, migration2To3, migration3To5, migration4To5);
 
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(versionProperty.getPath())).willReturn(1);
+        given(reader.getValue(versionProperty.getPath())).willReturn(1);
         ConfigurationData configurationData = mock(ConfigurationData.class);
 
         // when
@@ -141,7 +141,7 @@ class VersionMigrationServiceTest {
         VersionMigrationService migrationService = new VersionMigrationService(versionProperty, migration2To3, migration3To4);
 
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(versionProperty.getPath())).willReturn(0);
+        given(reader.getValue(versionProperty.getPath())).willReturn(0);
         ConfigurationData configurationData = mock(ConfigurationData.class);
 
         // when

--- a/src/test/java/ch/jalu/configme/properties/ArrayPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/ArrayPropertyTest.java
@@ -40,7 +40,7 @@ class ArrayPropertyTest {
             "singleton", StringType.STRING.arrayType(),
             "multiline", "message");
 
-        given(reader.getObject("singleton")).willReturn("hello");
+        given(reader.getValue("singleton")).willReturn("hello");
 
         // when
         String[] result = property.getFromReader(reader, new ConvertErrorRecorder());
@@ -56,7 +56,7 @@ class ArrayPropertyTest {
             "singleton", StringType.STRING, String[]::new,
             new String[] {"multiline", "message"});
 
-        given(reader.getObject("singleton")).willReturn(null);
+        given(reader.getValue("singleton")).willReturn(null);
 
         // when
         String[] result = property.getFromReader(reader, new ConvertErrorRecorder());
@@ -71,7 +71,7 @@ class ArrayPropertyTest {
         Property<String[]> property = new ArrayProperty<>(
             "array", StringType.STRING, String[]::new,
             new String[] {"multiline", "message"});
-        given(reader.getObject("array")).willReturn(Arrays.asList("qwerty", "123"));
+        given(reader.getValue("array")).willReturn(Arrays.asList("qwerty", "123"));
 
         // when
         PropertyValue<String[]> result = property.determineValue(reader);
@@ -87,7 +87,7 @@ class ArrayPropertyTest {
             "array", StringType.STRING, String[]::new,
             new String[] {"multiline", "message c:"});
 
-        given(reader.getObject("array")).willReturn(null);
+        given(reader.getValue("array")).willReturn(null);
 
         // when
         PropertyValue<String[]> result = property.determineValue(reader);
@@ -123,7 +123,7 @@ class ArrayPropertyTest {
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
         String value = "test";
         given(intArrayType.convert(value, errorRecorder)).willReturn(new Integer[]{3, 4});
-        given(reader.getObject(path)).willReturn(value);
+        given(reader.getValue(path)).willReturn(value);
 
         // when
         ArrayProperty<Integer> property = new ArrayProperty<>(path, intArrayType, 3, 8);

--- a/src/test/java/ch/jalu/configme/properties/BasePropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/BasePropertyTest.java
@@ -1,6 +1,7 @@
 package ch.jalu.configme.properties;
 
 import ch.jalu.configme.properties.convertresult.ConvertErrorRecorder;
+import ch.jalu.configme.properties.types.NumberType;
 import ch.jalu.configme.resource.PropertyReader;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -51,8 +52,8 @@ class BasePropertyTest {
     void shouldCheckIfIsValidInResource() {
         // given
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getInt("path.1")).willReturn(120);
-        given(reader.getInt("path.2")).willReturn(9999999);
+        given(reader.getValue("path.1")).willReturn(120);
+        given(reader.getValue("path.2")).willReturn(9999999);
         Property<Byte> property1 = new PropertyTestImpl("path.1", (byte) -89);
         Property<Byte> property2 = new PropertyTestImpl("path.2", (byte) -89);
 
@@ -72,7 +73,7 @@ class BasePropertyTest {
 
         @Override
         protected Byte getFromReader(@NotNull PropertyReader reader, @NotNull ConvertErrorRecorder errorRecorder) {
-            Integer value = reader.getInt(getPath());
+            Integer value = NumberType.INTEGER.convert(reader.getValue(getPath()), errorRecorder);
             return value != null && value >= Byte.MIN_VALUE && value <= Byte.MAX_VALUE
                 ? value.byteValue()
                 : null;

--- a/src/test/java/ch/jalu/configme/properties/BeanPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/BeanPropertyTest.java
@@ -107,7 +107,7 @@ class BeanPropertyTest {
             path, WorldGroupConfig.class, new WorldGroupConfig(), mapper);
         PropertyReader reader = mock(PropertyReader.class);
         Object value = new Object();
-        given(reader.getObject(path)).willReturn(value);
+        given(reader.getValue(path)).willReturn(value);
         WorldGroupConfig groupConfig = new WorldGroupConfig();
         given(mapper.convertToBean(eq(value), eq(new TypeInfo(WorldGroupConfig.class)), any(ConvertErrorRecorder.class)))
             .willReturn(groupConfig);

--- a/src/test/java/ch/jalu/configme/properties/BooleanPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/BooleanPropertyTest.java
@@ -25,8 +25,8 @@ class BooleanPropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("bool.path.test")).thenReturn(true);
-        when(reader.getObject("bool.path.wrong")).thenReturn(null);
+        when(reader.getValue("bool.path.test")).thenReturn(true);
+        when(reader.getValue("bool.path.wrong")).thenReturn(null);
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/CollectionPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/CollectionPropertyTest.java
@@ -41,7 +41,7 @@ class CollectionPropertyTest {
             CollectionPropertyType.of(NumberType.DOUBLE, Collectors.toCollection(TreeSet::new));
         Property<TreeSet<Double>> sortedValuesProperty =
             new CollectionProperty<>("values", treeSetType, new TreeSet<>());
-        given(reader.getObject("values")).willReturn(Arrays.asList(16, 9, 4));
+        given(reader.getValue("values")).willReturn(Arrays.asList(16, 9, 4));
 
         // when
         PropertyValue<TreeSet<Double>> value = sortedValuesProperty.determineValue(reader);
@@ -60,7 +60,7 @@ class CollectionPropertyTest {
             NumberType.DOUBLE,
             Collectors.toCollection(Vector::new),
             new Vector<>(Arrays.asList(3.0, 4.0)));
-        given(reader.getObject("values")).willReturn(Arrays.asList(1.0, 2.5, 4.0));
+        given(reader.getValue("values")).willReturn(Arrays.asList(1.0, 2.5, 4.0));
 
         // when
         PropertyValue<Vector<Double>> value = valuesProperty.determineValue(reader);
@@ -80,8 +80,8 @@ class CollectionPropertyTest {
         // given
         Property<List<Long>> property1 = CollectionProperty.of("p1", NumberType.LONG, Collectors.toList());
         Property<List<Long>> property2 = CollectionProperty.of("p2", NumberType.LONG, Collectors.toList(), 4L, 6L);
-        given(reader.getObject("p1")).willReturn("invalid");
-        given(reader.getObject("p2")).willReturn(Arrays.asList("1", "2"));
+        given(reader.getValue("p1")).willReturn("invalid");
+        given(reader.getValue("p2")).willReturn(Arrays.asList("1", "2"));
 
         // when
         PropertyValue<List<Long>> value1 = property1.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/properties/DoublePropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/DoublePropertyTest.java
@@ -26,7 +26,7 @@ class DoublePropertyTest {
     void shouldReturnDoubleFromResource() {
         // given
         Property<Double> property = new DoubleProperty("test.path", 3.4);
-        given(reader.getObject("test.path")).willReturn(-2508.346);
+        given(reader.getValue("test.path")).willReturn(-2508.346);
 
         // when
         PropertyValue<Double> result = property.determineValue(reader);
@@ -39,7 +39,7 @@ class DoublePropertyTest {
     void shouldReturnDefaultValue() {
         // given
         Property<Double> property = new DoubleProperty("property.path", 5.9);
-        given(reader.getObject("property.path")).willReturn(null);
+        given(reader.getValue("property.path")).willReturn(null);
 
         // when
         PropertyValue<Double> result = property.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/properties/EnumPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/EnumPropertyTest.java
@@ -24,7 +24,7 @@ class EnumPropertyTest {
         // given
         Property<TestEnum> property = new EnumProperty<>("enum.path", TestEnum.class, TestEnum.ENTRY_C);
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(property.getPath())).willReturn("Entry_B");
+        given(reader.getValue(property.getPath())).willReturn("Entry_B");
 
         // when
         PropertyValue<TestEnum> result = property.determineValue(reader);
@@ -38,7 +38,7 @@ class EnumPropertyTest {
         // given
         Property<TestEnum> property = new EnumProperty<>("enum.path", TestEnum.class, TestEnum.ENTRY_C);
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(property.getPath())).willReturn("Bogus");
+        given(reader.getValue(property.getPath())).willReturn("Bogus");
 
         // when
         PropertyValue<TestEnum> result = property.determineValue(reader);
@@ -52,7 +52,7 @@ class EnumPropertyTest {
         // given
         Property<TestEnum> property = new EnumProperty<>("enum.path", TestEnum.class, TestEnum.ENTRY_C);
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(property.getPath())).willReturn(null);
+        given(reader.getValue(property.getPath())).willReturn(null);
 
         // when
         PropertyValue<TestEnum> result = property.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/properties/EnumSetPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/EnumSetPropertyTest.java
@@ -28,7 +28,7 @@ class EnumSetPropertyTest {
         // given
         EnumSet<TestEnum> set = EnumSet.of(TestEnum.ENTRY_A);
         EnumSetProperty<TestEnum> property = new EnumSetProperty<>("enum.path", TestEnum.class, set);
-        given(reader.getObject(property.getPath())).willReturn(null);
+        given(reader.getValue(property.getPath())).willReturn(null);
 
         // when
         PropertyValue<EnumSet<TestEnum>> result = property.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/properties/FloatPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/FloatPropertyTest.java
@@ -26,7 +26,7 @@ class FloatPropertyTest {
     void shouldReturnFloatFromResource() {
         // given
         Property<Float> property = new FloatProperty("test.path", -4.11f);
-        given(reader.getObject("test.path")).willReturn(-2508.346);
+        given(reader.getValue("test.path")).willReturn(-2508.346);
 
         // when
         PropertyValue<Float> result = property.determineValue(reader);
@@ -39,7 +39,7 @@ class FloatPropertyTest {
     void shouldReturnDefaultValue() {
         // given
         Property<Float> property = new FloatProperty("property.path", 140f);
-        given(reader.getObject("property.path")).willReturn(null);
+        given(reader.getValue("property.path")).willReturn(null);
 
         // when
         PropertyValue<Float> result = property.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/properties/InlineArrayPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/InlineArrayPropertyTest.java
@@ -28,7 +28,7 @@ class InlineArrayPropertyTest {
             new String[] {"multiline", "message"}
         );
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("inline_value")).willReturn("hello\nkek");
+        given(reader.getValue("inline_value")).willReturn("hello\nkek");
 
         // when
         String[] result = property.getFromReader(reader, new ConvertErrorRecorder());
@@ -58,7 +58,7 @@ class InlineArrayPropertyTest {
         InlineArrayProperty<Integer> property = new InlineArrayProperty<>("path", InlineArrayPropertyType.INTEGER,  new Integer[0]);
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("path")).willReturn(value);
+        given(reader.getValue("path")).willReturn(value);
 
         // when
         Integer[] result = property.getFromReader(reader, errorRecorder);

--- a/src/test/java/ch/jalu/configme/properties/IntegerPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/IntegerPropertyTest.java
@@ -25,8 +25,8 @@ class IntegerPropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("int.path.test")).thenReturn(27);
-        when(reader.getObject("int.path.wrong")).thenReturn(null);
+        when(reader.getValue("int.path.test")).thenReturn(27);
+        when(reader.getValue("int.path.wrong")).thenReturn(null);
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/ListPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/ListPropertyTest.java
@@ -39,7 +39,7 @@ class ListPropertyTest {
     void shouldReturnValueFromResource() {
         // given
         Property<List<Integer>> property = new ListProperty<>("list", NumberType.INTEGER);
-        given(reader.getObject("list")).willReturn(Arrays.asList(3, 5, 7.0));
+        given(reader.getValue("list")).willReturn(Arrays.asList(3, 5, 7.0));
 
         // when
         PropertyValue<List<Integer>> result = property.determineValue(reader);
@@ -52,7 +52,7 @@ class ListPropertyTest {
     void shouldReturnDefaultValue() {
         // given
         Property<List<Integer>> property = new ListProperty<>("list", NumberType.INTEGER, 8, 9, 10);
-        given(reader.getObject("list")).willReturn(null);
+        given(reader.getValue("list")).willReturn(null);
 
         // when
         PropertyValue<List<Integer>> result = property.determineValue(reader);
@@ -101,7 +101,7 @@ class ListPropertyTest {
         ConvertErrorRecorder errorRecorder = new ConvertErrorRecorder();
         String value = "s,h";
         given(timeUnitListType.convert(value, errorRecorder)).willReturn(Arrays.asList(TimeUnit.SECONDS, TimeUnit.HOURS));
-        given(reader.getObject(path)).willReturn(value);
+        given(reader.getValue(path)).willReturn(value);
 
         // when
         ListProperty<TimeUnit> property = ListProperty.withListType(path, timeUnitListType, singletonList(TimeUnit.DAYS));

--- a/src/test/java/ch/jalu/configme/properties/LocalDatePropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/LocalDatePropertyTest.java
@@ -27,8 +27,8 @@ class LocalDatePropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("local-date.path.test")).thenReturn("1999-01-31");
-        when(reader.getObject("local-date.path.wrong")).thenReturn("31-01-1999");
+        when(reader.getValue("local-date.path.test")).thenReturn("1999-01-31");
+        when(reader.getValue("local-date.path.wrong")).thenReturn("31-01-1999");
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/LocalDateTimePropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/LocalDateTimePropertyTest.java
@@ -27,8 +27,8 @@ class LocalDateTimePropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("local-date-time.path.test")).thenReturn("2001-10-20 19:55:30");
-        when(reader.getObject("local-date-time.path.wrong")).thenReturn("20-2001-10 55:19:30");
+        when(reader.getValue("local-date-time.path.test")).thenReturn("2001-10-20 19:55:30");
+        when(reader.getValue("local-date-time.path.wrong")).thenReturn("20-2001-10 55:19:30");
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/LocalTimePropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/LocalTimePropertyTest.java
@@ -27,8 +27,8 @@ class LocalTimePropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("local-time.path.test")).thenReturn("19:55:30");
-        when(reader.getObject("local-time.path.wrong")).thenReturn("55:19:30");
+        when(reader.getValue("local-time.path.test")).thenReturn("19:55:30");
+        when(reader.getValue("local-time.path.wrong")).thenReturn("55:19:30");
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/LongPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/LongPropertyTest.java
@@ -25,8 +25,8 @@ class LongPropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("long.path.test")).thenReturn(30L);
-        when(reader.getObject("long.path.wrong")).thenReturn(null);
+        when(reader.getValue("long.path.test")).thenReturn(30L);
+        when(reader.getValue("long.path.wrong")).thenReturn(null);
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/LowercaseStringSetPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/LowercaseStringSetPropertyTest.java
@@ -33,10 +33,10 @@ class LowercaseStringSetPropertyTest {
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
         List<String> stringList = Arrays.asList("test1", "Test2", "3rd TEST");
-        given(reader.getObject("lowercaselist.path.test")).willReturn(stringList);
-        given(reader.getObject("lowercaselist.path.wrong")).willReturn(null);
+        given(reader.getValue("lowercaselist.path.test")).willReturn(stringList);
+        given(reader.getValue("lowercaselist.path.wrong")).willReturn(null);
         List<Object> mixedList = Arrays.asList('b', "test", 1);
-        given(reader.getObject("lowercaselist.path.mixed")).willReturn(mixedList);
+        given(reader.getValue("lowercaselist.path.mixed")).willReturn(mixedList);
     }
 
     @Test
@@ -82,7 +82,7 @@ class LowercaseStringSetPropertyTest {
         // given
         Property<Set<String>> property = new LowercaseStringSetProperty("path");
         List<?> list = Arrays.asList(null, "test", null, "test");
-        given(reader.getObject(property.getPath())).willReturn(list);
+        given(reader.getValue(property.getPath())).willReturn(list);
 
         // when
         PropertyValue<Set<String>> result = property.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/properties/MapPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/MapPropertyTest.java
@@ -50,7 +50,7 @@ class MapPropertyTest {
         // given
         MapProperty<String> property = new MapProperty<>("map", StringType.STRING, new HashMap<>());
         Map<String, String> mapFromReader = createSampleMap();
-        given(reader.getObject("map")).willReturn(mapFromReader);
+        given(reader.getValue("map")).willReturn(mapFromReader);
 
         // when / then
         assertThat(property.determineValue(reader), isValidValueOf(mapFromReader));
@@ -60,7 +60,7 @@ class MapPropertyTest {
     void shouldReturnDefaultValue() {
         // given
         MapProperty<String> property = new MapProperty<>("map", StringType.STRING, createSampleMap());
-        given(reader.getObject("map")).willReturn(null);
+        given(reader.getValue("map")).willReturn(null);
 
         // when / then
         assertThat(property.determineValue(reader), isErrorValueOf(property.getDefaultValue()));
@@ -146,7 +146,7 @@ class MapPropertyTest {
         Map<Integer, Integer> inputMap = new LinkedHashMap<>();
         inputMap.put(1, 1);
         inputMap.put(4, 4);
-        given(reader.getObject("mapping")).willReturn(inputMap);
+        given(reader.getValue("mapping")).willReturn(inputMap);
 
         // when
         PropertyValue<Map<String, Double>> propertyValue = mapProperty.determineValue(reader);
@@ -174,7 +174,7 @@ class MapPropertyTest {
         Map<Integer, Integer> inputMap = new LinkedHashMap<>();
         inputMap.put(8, 3);
         inputMap.put(4, 6);
-        given(reader.getObject("mapping")).willReturn(inputMap);
+        given(reader.getValue("mapping")).willReturn(inputMap);
 
         // when
         PropertyValue<Map<String, Double>> propertyValue = mapProperty.determineValue(reader);

--- a/src/test/java/ch/jalu/configme/properties/OptionalPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/OptionalPropertyTest.java
@@ -41,9 +41,9 @@ class OptionalPropertyTest {
         OptionalProperty<Integer> intProp = new OptionalProperty<>("int.path.test", NumberType.INTEGER);
         OptionalProperty<TestEnum> enumProp = new OptionalProperty<>("enum.path.test", new EnumPropertyType<>(TestEnum.class));
 
-        given(reader.getObject("bool.path.test")).willReturn(true);
-        given(reader.getObject("int.path.test")).willReturn(27);
-        given(reader.getObject("enum.path.test")).willReturn(TestEnum.FOURTH.name());
+        given(reader.getValue("bool.path.test")).willReturn(true);
+        given(reader.getValue("int.path.test")).willReturn(27);
+        given(reader.getValue("enum.path.test")).willReturn(TestEnum.FOURTH.name());
 
         // when
         PropertyValue<Optional<Boolean>> boolResult = booleanProp.determineValue(reader);
@@ -89,7 +89,7 @@ class OptionalPropertyTest {
     @Test
     void shouldReturnValueWithInvalidFlagIfReturnedFromReader() {
         // given
-        given(reader.getObject("the.path")).willReturn(400);
+        given(reader.getValue("the.path")).willReturn(400);
         OptionalProperty<Byte> optionalProperty = new OptionalProperty<>("the.path", NumberType.BYTE);
 
         // when

--- a/src/test/java/ch/jalu/configme/properties/RegexPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/RegexPropertyTest.java
@@ -38,7 +38,7 @@ class RegexPropertyTest {
         // given
         RegexProperty property = new RegexProperty("names.whitelist", "s_.*?");
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("names.whitelist")).willReturn("m[0-9]+");
+        given(reader.getValue("names.whitelist")).willReturn("m[0-9]+");
         ConvertErrorRecorder convertErrorRecorder = new ConvertErrorRecorder();
 
         // when
@@ -53,7 +53,7 @@ class RegexPropertyTest {
         // given
         RegexProperty property = new RegexProperty("names.whitelist", "s_.*?");
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("names.whitelist")).willReturn(null);
+        given(reader.getValue("names.whitelist")).willReturn(null);
         ConvertErrorRecorder convertErrorRecorder = new ConvertErrorRecorder();
 
         // when
@@ -68,7 +68,7 @@ class RegexPropertyTest {
         // given
         RegexProperty property = new RegexProperty("names.whitelist", "s_.*?");
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("names.whitelist")).willReturn("m[0-9+");
+        given(reader.getValue("names.whitelist")).willReturn("m[0-9+");
         ConvertErrorRecorder convertErrorRecorder = new ConvertErrorRecorder();
 
         // when
@@ -106,7 +106,7 @@ class RegexPropertyTest {
         // given
         RegexProperty property = RegexProperty.caseInsensitive("validName", "\\d+");
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("validName")).willReturn("[a-z_]+");
+        given(reader.getValue("validName")).willReturn("[a-z_]+");
 
 
         // when

--- a/src/test/java/ch/jalu/configme/properties/SetPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/SetPropertyTest.java
@@ -37,7 +37,7 @@ class SetPropertyTest {
             1.414, 1.732, 2.0);
         PropertyReader reader = mock(PropertyReader.class);
         List<Double> list = Arrays.asList(3.6, 6.9, 10.2);
-        given(reader.getObject("error.codes")).willReturn(list);
+        given(reader.getValue("error.codes")).willReturn(list);
 
         // when
         PropertyValue<Set<Double>> result = property.determineValue(reader);
@@ -53,7 +53,7 @@ class SetPropertyTest {
         SetProperty<Integer> property = new SetProperty<>("error.codes", NumberType.INTEGER,
             -27, -8);
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject("error.codes")).willReturn(null);
+        given(reader.getValue("error.codes")).willReturn(null);
 
         // when
         PropertyValue<Set<Integer>> result = property.determineValue(reader);
@@ -107,7 +107,7 @@ class SetPropertyTest {
         LinkedHashSet<String> convertedValue = new LinkedHashSet<>(Arrays.asList("α", "μ"));
         given(greekStringSetType.convert(value, errorRecorder)).willReturn(convertedValue);
         PropertyReader reader = mock(PropertyReader.class);
-        given(reader.getObject(path)).willReturn(value);
+        given(reader.getValue(path)).willReturn(value);
 
         // when
         SetProperty<String> property = SetProperty.withSetType(path, greekStringSetType, singleton("θ"));

--- a/src/test/java/ch/jalu/configme/properties/ShortPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/ShortPropertyTest.java
@@ -25,8 +25,8 @@ class ShortPropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("short.path.test")).thenReturn((short) 15);
-        when(reader.getObject("short.path.wrong")).thenReturn(null);
+        when(reader.getValue("short.path.test")).thenReturn((short) 15);
+        when(reader.getValue("short.path.wrong")).thenReturn(null);
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/StringListPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/StringListPropertyTest.java
@@ -31,10 +31,10 @@ class StringListPropertyTest {
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
         List<String> stringList = Arrays.asList("test1", "Test2", "3rd test");
-        given(reader.getObject("list.path.test")).willReturn(stringList);
-        given(reader.getObject("list.path.wrong")).willReturn(null);
+        given(reader.getValue("list.path.test")).willReturn(stringList);
+        given(reader.getValue("list.path.wrong")).willReturn(null);
         List<Object> mixedList = Arrays.asList("test1", false, "toast", 1);
-        given(reader.getObject("list.path.mixed")).willReturn(mixedList);
+        given(reader.getValue("list.path.mixed")).willReturn(mixedList);
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/StringPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/StringPropertyTest.java
@@ -23,8 +23,8 @@ class StringPropertyTest {
     @BeforeAll
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
-        when(reader.getObject("str.path.test")).thenReturn("Test value");
-        when(reader.getObject("str.path.wrong")).thenReturn(null);
+        when(reader.getValue("str.path.test")).thenReturn("Test value");
+        when(reader.getValue("str.path.wrong")).thenReturn(null);
     }
 
     @Test
@@ -68,8 +68,8 @@ class StringPropertyTest {
         // given
         Property<String> property1 = new StringProperty("one", "");
         Property<String> property2 = new StringProperty("two", "");
-        given(reader.getObject(property1.getPath())).willReturn(1);
-        given(reader.getObject(property2.getPath())).willReturn(-5.328);
+        given(reader.getValue(property1.getPath())).willReturn(1);
+        given(reader.getValue(property2.getPath())).willReturn(-5.328);
 
         // when
         String value1 = property1.determineValue(reader).getValue();
@@ -84,7 +84,7 @@ class StringPropertyTest {
     void shouldReturnStringFromBoolean() {
         // given
         Property<String> property = new StringProperty("test", "");
-        given(reader.getObject(property.getPath())).willReturn(false);
+        given(reader.getValue(property.getPath())).willReturn(false);
 
         // when
         String value = property.determineValue(reader).getValue();

--- a/src/test/java/ch/jalu/configme/properties/StringSetPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/StringSetPropertyTest.java
@@ -32,10 +32,10 @@ class StringSetPropertyTest {
     static void setUpConfiguration() {
         reader = mock(PropertyReader.class);
         List<String> stringList = Arrays.asList("test1", "Test2", "3rd test", "Test2");
-        given(reader.getObject("list.path.test")).willReturn(stringList);
-        given(reader.getObject("list.path.wrong")).willReturn(null);
+        given(reader.getValue("list.path.test")).willReturn(stringList);
+        given(reader.getValue("list.path.wrong")).willReturn(null);
         List<Object> mixedList = Arrays.asList("test1", false, "toast", 1);
-        given(reader.getObject("list.path.mixed")).willReturn(mixedList);
+        given(reader.getValue("list.path.mixed")).willReturn(mixedList);
     }
 
     @Test

--- a/src/test/java/ch/jalu/configme/properties/TypeBasedPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/properties/TypeBasedPropertyTest.java
@@ -29,7 +29,7 @@ class TypeBasedPropertyTest {
     void shouldReturnValueFromResource() {
         // given
         Property<String> property = new TypeBasedProperty<>("common.path", StringType.STRING, "default");
-        given(reader.getObject("common.path")).willReturn("some string");
+        given(reader.getValue("common.path")).willReturn("some string");
 
         // when / then
         assertThat(property.determineValue(reader), isValidValueOf("some string"));

--- a/src/test/java/ch/jalu/configme/resource/YamlFileReaderTest.java
+++ b/src/test/java/ch/jalu/configme/resource/YamlFileReaderTest.java
@@ -204,8 +204,8 @@ class YamlFileReaderTest {
         // then
         assertThat(result, sameInstance(configFile));
         assertThat(reader.getRoot(), nullValue());
-        assertThat(reader.getKeys(true), empty());
-        assertThat(reader.getChildKeys(""), empty());
+        assertThat(reader.getLeafPaths(), empty());
+        assertThat(reader.getChildPaths(""), empty());
     }
 
     @Test
@@ -232,16 +232,16 @@ class YamlFileReaderTest {
     }
 
     @Test
-    void shouldReturnKeysOfFile() {
+    void shouldReturnPathsOfFile() {
         // given
         Path file = copyFileFromResources(COMPLETE_FILE);
         YamlFileReader reader = new YamlFileReader(file);
 
         // when
-        Set<String> keys = reader.getKeys(false);
+        Set<String> paths = reader.getPaths();
 
         // then
-        assertThat(keys, contains("test", "test.duration", "test.systemName",
+        assertThat(paths, contains("test", "test.duration", "test.systemName",
             "sample", "sample.ratio", "sample.ratio.order", "sample.ratio.fields",
             "version",
             "features", "features.boring", "features.boring.skip", "features.boring.colors", "features.boring.dustLevel",
@@ -250,16 +250,16 @@ class YamlFileReaderTest {
     }
 
     @Test
-    void shouldReturnLeafNodeKeysInFile() {
+    void shouldReturnLeafPathsInFile() {
         // given
         Path file = copyFileFromResources(COMPLETE_FILE);
         YamlFileReader reader = new YamlFileReader(file);
 
         // when
-        Set<String> keys = reader.getKeys(true);
+        Set<String> paths = reader.getLeafPaths();
 
         // then
-        assertThat(keys, contains("test.duration", "test.systemName",
+        assertThat(paths, contains("test.duration", "test.systemName",
             "sample.ratio.order", "sample.ratio.fields",
             "version",
             "features.boring.skip", "features.boring.colors", "features.boring.dustLevel",
@@ -274,11 +274,11 @@ class YamlFileReaderTest {
         YamlFileReader reader = new YamlFileReader(file);
 
         // when
-        Set<String> keys = reader.getKeys(true);
+        Set<String> paths = reader.getLeafPaths();
 
         // then
-        assertThat(keys, hasSize(24));
-        assertThat(keys, hasItems(
+        assertThat(paths, hasSize(24));
+        assertThat(paths, hasItems(
             "message-key.conditionalElem.conditionals.low.conditionals", // empty map
             "message-key.conditionalElem.conditionals.med.color",
             "message-key.conditionalElem.conditionals.high.conditionalElem.bold",
@@ -290,29 +290,29 @@ class YamlFileReaderTest {
     }
 
     @Test
-    void shouldReturnChildrenPathsOfGivenPath() {
+    void shouldReturnChildPathsOfGivenPath() {
         // given
         Path file = copyFileFromResources(COMPLETE_FILE);
         YamlFileReader reader = new YamlFileReader(file);
 
         // when
-        Set<String> keys = reader.getChildKeys("features.boring");
+        Set<String> paths = reader.getChildPaths("features.boring");
 
         // then
-        assertThat(keys, contains("features.boring.skip", "features.boring.colors", "features.boring.dustLevel"));
+        assertThat(paths, contains("features.boring.skip", "features.boring.colors", "features.boring.dustLevel"));
     }
 
     @Test
-    void shouldReturnChildrenPathsOfRoot() {
+    void shouldReturnChildPathsOfRoot() {
         // given
         Path file = copyFileFromResources(COMPLETE_FILE);
         YamlFileReader reader = new YamlFileReader(file);
 
         // when
-        Set<String> keys = reader.getChildKeys("");
+        Set<String> paths = reader.getChildPaths("");
 
         // then
-        assertThat(keys, contains("test", "sample", "version", "features", "security"));
+        assertThat(paths, contains("test", "sample", "version", "features", "security"));
     }
 
     @Test
@@ -322,8 +322,8 @@ class YamlFileReaderTest {
         YamlFileReader reader = new YamlFileReader(file);
 
         // when
-        Set<String> bogusChildren = reader.getChildKeys("bogus");
-        Set<String> leafChildren = reader.getChildKeys("features.boring.colors");
+        Set<String> bogusChildren = reader.getChildPaths("bogus");
+        Set<String> leafChildren = reader.getChildPaths("features.boring.colors");
 
         // then
         assertThat(bogusChildren, empty());

--- a/src/test/java/ch/jalu/configme/resource/YamlFileReaderTest.java
+++ b/src/test/java/ch/jalu/configme/resource/YamlFileReaderTest.java
@@ -116,6 +116,7 @@ class YamlFileReaderTest {
         assertThat(reader.getBoolean(TestConfiguration.DURATION_IN_SECONDS.getPath()), nullValue());
         assertThat(reader.getString(TestConfiguration.DURATION_IN_SECONDS.getPath()), equalTo("22"));
         assertThat(reader.getDouble(TestConfiguration.DURATION_IN_SECONDS.getPath()), equalTo(22.0));
+        assertThat(reader.getObject(TestConfiguration.DURATION_IN_SECONDS.getPath()), equalTo(22));
         assertThat(reader.getDouble(TestConfiguration.SKIP_BORING_FEATURES.getPath()), nullValue());
     }
 

--- a/src/test/java/ch/jalu/configme/resource/YamlFileReaderTest.java
+++ b/src/test/java/ch/jalu/configme/resource/YamlFileReaderTest.java
@@ -114,7 +114,7 @@ class YamlFileReaderTest {
 
         // when / then
         assertThat(reader.getBoolean(TestConfiguration.DURATION_IN_SECONDS.getPath()), nullValue());
-        assertThat(reader.getString(TestConfiguration.DURATION_IN_SECONDS.getPath()), nullValue());
+        assertThat(reader.getString(TestConfiguration.DURATION_IN_SECONDS.getPath()), equalTo("22"));
         assertThat(reader.getDouble(TestConfiguration.DURATION_IN_SECONDS.getPath()), equalTo(22.0));
         assertThat(reader.getDouble(TestConfiguration.SKIP_BORING_FEATURES.getPath()), nullValue());
     }
@@ -157,7 +157,7 @@ class YamlFileReaderTest {
         PropertyReader reader = new YamlFileReader(file);
 
         // when
-        Object result = reader.getObject("");
+        Object result = reader.getValue("");
 
         // then
         assertThat(result, instanceOf(Map.class));
@@ -171,8 +171,8 @@ class YamlFileReaderTest {
         YamlFileReader reader = new YamlFileReader(file);
 
         // when / then
-        assertThat(reader.getObject("sample.ratio.wrong.dunno"), nullValue());
-        assertThat(reader.getObject(TestConfiguration.RATIO_ORDER.getPath() + ".child"), nullValue());
+        assertThat(reader.getValue("sample.ratio.wrong.dunno"), nullValue());
+        assertThat(reader.getValue(TestConfiguration.RATIO_ORDER.getPath() + ".child"), nullValue());
         assertThat(reader.getRoot().keySet(), containsInAnyOrder("test", "sample", "version", "features", "security"));
     }
 

--- a/src/test/java/ch/jalu/configme/resource/YamlFileResourceOptionalInBeanPropertyTest.java
+++ b/src/test/java/ch/jalu/configme/resource/YamlFileResourceOptionalInBeanPropertyTest.java
@@ -44,7 +44,7 @@ class YamlFileResourceOptionalInBeanPropertyTest {
         PropertyResource resource = new YamlFileResource(file);
         PropertyReader reader = resource.createReader();
         Mapper mapper = new MapperImpl();
-        ComplexCommandConfig result = mapper.convertToBean(reader.getObject("commandconfig"), ComplexCommandConfig.class, new ConvertErrorRecorder());
+        ComplexCommandConfig result = mapper.convertToBean(reader.getValue("commandconfig"), ComplexCommandConfig.class, new ConvertErrorRecorder());
         result.getCommands().put("shutdown", createShutdownCommand());
         ConfigurationData configurationData = createConfigurationData();
         configurationData.setValue(commandConfigProperty, result);
@@ -56,7 +56,7 @@ class YamlFileResourceOptionalInBeanPropertyTest {
         PropertyResource resourceAfterSave = new YamlFileResource(file);
         ConvertErrorRecorder errorRecorderAfterSave = new ConvertErrorRecorder();
         ComplexCommandConfig commandConfig = mapper.convertToBean(
-            resourceAfterSave.createReader().getObject("commandconfig"), ComplexCommandConfig.class, errorRecorderAfterSave);
+            resourceAfterSave.createReader().getValue("commandconfig"), ComplexCommandConfig.class, errorRecorderAfterSave);
         assertThat(errorRecorderAfterSave.isFullyValid(), equalTo(true));
 
         assertThat(commandConfig.getCommands().keySet(),

--- a/src/test/java/ch/jalu/configme/resource/YamlFileResourceTest.java
+++ b/src/test/java/ch/jalu/configme/resource/YamlFileResourceTest.java
@@ -89,7 +89,7 @@ class YamlFileResourceTest {
             // If we go through Property objects they may fall back to their default values
             String propertyPath = entry.getKey().getPath();
             assertThat("Property '" + propertyPath + "' has expected value",
-               reader.getObject(propertyPath), equalTo(entry.getValue()));
+               reader.getValue(propertyPath), equalTo(entry.getValue()));
         }
     }
 
@@ -113,7 +113,7 @@ class YamlFileResourceTest {
 
         // then
         PropertyReader reader = resource.createReader();
-        assertThat(reader.getObject(TestConfiguration.DUST_LEVEL.getPath()), not(nullValue()));
+        assertThat(reader.getValue(TestConfiguration.DUST_LEVEL.getPath()), not(nullValue()));
 
         Map<Property<?>, Object> expected = new HashMap<>();
         expected.put(TestConfiguration.DURATION_IN_SECONDS, 20);
@@ -131,7 +131,7 @@ class YamlFileResourceTest {
 
         for (Map.Entry<Property<?>, Object> entry : expected.entrySet()) {
             assertThat("Property '" + entry.getKey().getPath() + "' has expected value",
-                reader.getObject(entry.getKey().getPath()), equalTo(entry.getValue()));
+                reader.getValue(entry.getKey().getPath()), equalTo(entry.getValue()));
         }
     }
 

--- a/src/test/java/ch/jalu/configme/utils/MigrationUtilsTest.java
+++ b/src/test/java/ch/jalu/configme/utils/MigrationUtilsTest.java
@@ -32,7 +32,7 @@ class MigrationUtilsTest {
         PropertyReader reader = mock(PropertyReader.class);
         given(reader.contains(oldProperty.getPath())).willReturn(true);
         given(reader.contains(newProperty.getPath())).willReturn(false);
-        given(reader.getObject(oldProperty.getPath())).willReturn(22);
+        given(reader.getValue(oldProperty.getPath())).willReturn(22);
 
         // when
         boolean result = MigrationUtils.moveProperty(oldProperty, newProperty, reader, configurationData);


### PR DESCRIPTION
* New interface `PathProvider` with the path enumeration methods that property reader implementations can optionally implement. This way, quick implementations of `PropertyReader` don't need to worry about that functionality (ConfigMe doesn't need it anywhere)
* Deprecate #getString, #getInt & similar in favor of reading from the reader via Property instances (or PropertyType)